### PR TITLE
Adicionar validação de campos ao criar paciente

### DIFF
--- a/codificação/inclua/app/Http/Controllers/PacienteController.php
+++ b/codificação/inclua/app/Http/Controllers/PacienteController.php
@@ -45,7 +45,7 @@ class PacienteController extends Controller
         $rules = [
             "nome" => "required|min:5",
             "documento" => "required|unique:users,documento,{$request->usuario_id}",
-            "data_nascimento" => "required",
+            'data_nascimento' => 'required|date|before_or_equal:today',
             "sexo" => "required"
         ];
         $feedbacks = [
@@ -71,10 +71,16 @@ class PacienteController extends Controller
             $msg = ['valor' => trans("Cadastro do paciente realizado com sucesso!"), 'tipo' => 'success'];
             session()->flash('msg', $msg);
         } catch (QueryException $e) {
+            if ($e->errorInfo[1] == 1062) {
+
+                $msg = ['valor' => trans("Já existe um paciente com este CPF. Tente novamente."), 'tipo' => 'danger'];
+                session()->flash('msg', $msg);
+                return back()->withInput();
+
+            }
             $msg = ['valor' => trans("Houve um erro ao realizar o cadastro do paciente. Tente novamente."), 'tipo' => 'danger'];
             session()->flash('msg', $msg);
-
-            return back();
+            return back()->withInput();
         }
 
         return redirect()->route('paciente.index');

--- a/codificação/inclua/app/Http/Controllers/PacienteController.php
+++ b/codificação/inclua/app/Http/Controllers/PacienteController.php
@@ -86,6 +86,59 @@ class PacienteController extends Controller
         return redirect()->route('paciente.index');
     }
 
+    public function edit($id) {
+        $paciente = Paciente::find($id);
+        return view('userPaciente.paciente.edit', ['paciente' => $paciente]);
+    }
+
+    public function update(Request $request) {
+        $request->request->set('documento', Helper::removerCaractereEspecial($request->documento));
+        $rules = [
+            "nome" => "required|min:5",
+            "documento" => "required|unique:users,documento,{$request->usuario_id}",
+            'data_nascimento' => 'required|date|before_or_equal:today',
+            "sexo" => "required"
+        ];
+        $feedbacks = [
+            "nome.required" => "O campo Nome é obrigatório.",
+            "nome.min" => "O campo nome deve ter no mínomo 5 caracteres.",
+            "documento.required" => "O campo CPF é obrigatório.",
+            "documento.unique" => "Este CPF já foi utilizado.",
+            "data_nascimento.required" => "O campo Data de nascimento é obrigatório.",
+            "estado_civil.required" => "O campo Estado civil é obrigatório.",
+            "sexo.required" => "O campo Gênero é obrigatório."
+        ];
+
+        $request->validate($rules, $feedbacks);
+
+        try {
+
+        $paciente = Paciente::find($request->id);
+        $paciente->usuario_id = Auth::user()->id;
+        $paciente->nome = $request->nome;
+        $paciente->data_nascimento = $request->data_nascimento;
+        $paciente->sexo = $request->sexo;
+        $paciente->cpf = $request->documento;
+        $paciente->save();
+
+        $msg = ['valor' => trans("Edição do paciente realizada com sucesso!"), 'tipo' => 'success'];
+            session()->flash('msg', $msg);
+        } catch (QueryException $e) {
+            if ($e->errorInfo[1] == 1062) {
+
+                $msg = ['valor' => trans("Já existe um paciente com este CPF. Tente novamente."), 'tipo' => 'danger'];
+                session()->flash('msg', $msg);
+                return back()->withInput();
+
+            }
+            $msg = ['valor' => trans("Houve um erro ao realizar o cadastro do paciente. Tente novamente."), 'tipo' => 'danger'];
+            session()->flash('msg', $msg);
+            return back()->withInput();
+        }
+
+        return redirect()->route('paciente.index');
+    }
+
     public function createDadosUserPaciente($usuario_id)
     {
         return view('cadastro.paciente.form_dados', ['usuario_id' => $usuario_id]);

--- a/codificação/inclua/resources/views/userPaciente/paciente/edit.blade.php
+++ b/codificação/inclua/resources/views/userPaciente/paciente/edit.blade.php
@@ -1,0 +1,94 @@
+@extends('layouts.app', ['page' => __('Pacientes'), 'exibirPesquisa' => false, 'pageSlug' => 'pacientes', 'class' => 'pacientes'])
+@section('title', 'Cadastro de paciente')
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="title">Edição de paciente</h4>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ route('paciente.update') }}">
+                        @csrf
+                        <div class="row">
+                            <div class="col-md-3">
+                                <div class="form-group">
+                                    <label for="nome">
+                                        Nome <span class="required">*</span>
+                                    </label>
+                                    <div class="input-group {{ $errors->has('nome') ? 'has-danger' : '' }}">
+                                        <input type="text" id="nome" class="form-control {{ $errors->has('nome') ? 'is-invalid' : '' }}" name="nome"
+                                            placeholder="Nome completo..." value="{{ old('nome', $paciente->nome) }}" required>
+                                        @include('alerts.feedback', ['field' => 'nome'])
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <div class="form-group">
+                                    <label for="documento">
+                                        CPF <span class="required">*</span>
+                                    </label>
+                                    <div class="input-group {{ $errors->has('documento') ? 'has-danger' : '' }}">
+                                        <input type="text" id="documento" class="form-control {{ $errors->has('documento') ? 'is-invalid' : '' }}"
+                                            name="documento" maxlength="14" placeholder="000.000.000-00" oninput="mascaraCpf(this)" onblur="validarCPF(this)"
+                                            value="{{ old("documento", $paciente->cpf) }}" required>
+                                        @include('alerts.feedback', ['field' => 'documento'])
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <div class="form-group">
+                                    <label for="data_nascimento">
+                                        Data de nascimento <span class="required">*</span>
+                                    </label>    
+                                    <div class="input-group {{ $errors->has('data_nascimento') ? 'has-danger' : '' }}">
+                                        <input type="date" 
+                                           id="data_nascimento" 
+                                           class="form-control {{ $errors->has('data_nascimento') ? 'is-invalid' : '' }}"
+                                           name="data_nascimento" 
+                                           value="{{ old("data_nascimento", $paciente->data_nascimento) }}" 
+                                           max="{{ date('Y-m-d') }}" 
+                                           required>
+
+                                        @include('alerts.feedback', ['field' => 'data_nascimento'])
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <div class="form-group">
+                                    <label for="sexo">
+                                        Gênero <span class="required">*</span>
+                                    </label>
+
+                                    <div class="input-group {{ $errors->has('sexo') ? 'has-danger' : '' }}">
+                                        <select name="sexo" class="form-control {{ $errors->has('sexo') ? 'is-invalid' : '' }}" required>
+                                            <option value="F" @if (old('sexo', $paciente->sexo) == 'F') selected @endif>Feminino</option>
+                                            <option value="M" @if (old('sexo', $paciente->sexo) == 'M') selected @endif>Masculino</option>
+                                            <option value="O" @if (old('sexo', $paciente->sexo) == 'O') selected @endif>Outro</option>
+                                            <option value="N" @if (old('sexo', $paciente->sexo) == 'N') selected @endif>Prefiro não informar</option>
+                                        </select>
+                                        @include('alerts.feedback', ['field' => 'sexo'])
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-12">
+                                <a href="{{ url()->previous() }}" class="btn btn-primary">
+                                    <i class="fa fa-reply"></i> Voltar
+                                </a>
+                                <button type="submit" class="btn btn-primary">
+                                    Editar <i class="fa fa-save"></i>
+                                </button>
+                            </div>
+                        </div>
+                        
+                        <input type="hidden" name="id" value="{{ $paciente->id }}">
+                        <input type="hidden" name="especialista_id" value="">
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/codificação/inclua/resources/views/userPaciente/paciente/form.blade.php
+++ b/codificação/inclua/resources/views/userPaciente/paciente/form.blade.php
@@ -40,10 +40,16 @@
                                 <div class="form-group">
                                     <label for="data_nascimento">
                                         Data de nascimento <span class="required">*</span>
-                                    </label>
+                                    </label>    
                                     <div class="input-group {{ $errors->has('data_nascimento') ? 'has-danger' : '' }}">
-                                        <input type="date" id="data_nascimento" class="form-control {{ $errors->has('data_nascimento') ? 'is-invalid' : '' }}"
-                                            name="data_nascimento" value="{{ old('data_nascimento') }}" required>
+                                        <input type="date" 
+                                           id="data_nascimento" 
+                                           class="form-control {{ $errors->has('data_nascimento') ? 'is-invalid' : '' }}"
+                                           name="data_nascimento" 
+                                           value="{{ old('data_nascimento') }}" 
+                                           max="{{ date('Y-m-d') }}" 
+                                           required>
+
                                         @include('alerts.feedback', ['field' => 'data_nascimento'])
                                     </div>
                                 </div>

--- a/codificação/inclua/resources/views/userPaciente/paciente/lista.blade.php
+++ b/codificação/inclua/resources/views/userPaciente/paciente/lista.blade.php
@@ -23,6 +23,8 @@
                                     <th>Nome</th>
                                     <th>Sexo</th>
                                     <th>Data de Nascimento</th>
+                                    <th>Editar</th>
+                                    <th>Excluir</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -44,6 +46,14 @@
                                         </td>
                                         <td>
                                             {{ isset($paciente->data_nascimento) ? date('d/m/Y', strtotime($paciente->data_nascimento)) : "-" }}
+                                        </td>
+                                        <td class="td-actions text-left">
+                                            <a href="{{ route('paciente.edit', $paciente->id) }}">
+                                                <button type="button" rel="tooltip" title="Editar" class="btn btn-link"
+                                                        data-original-title="Edit Task" style="color: white;">
+                                                    <i class="tim-icons icon-pencil"></i>
+                                                </button>
+                                            </a>
                                         </td>
                                     </tr>
                                 @endforeach

--- a/codificação/inclua/routes/web.php
+++ b/codificação/inclua/routes/web.php
@@ -250,6 +250,8 @@ Route::middleware('auth')->group(function () {
     Route::get("/paciente/assinatura/renovar/{cartao}", [\App\Http\Controllers\AssinaturaController::class, 'renovarAssinaturaCartao'])->name('pagamento.assinatura.renovar');
     
     #LISTA PACIENTES E CADASTRO
+    Route::get("/paciente/editar/{id}", [\App\Http\Controllers\PacienteController::class, 'edit'])->name('paciente.edit');
+    Route::post("/paciente/update/", [\App\Http\Controllers\PacienteController::class, 'update'])->name('paciente.update');
     Route::get("/paciente/lista", [\App\Http\Controllers\PacienteController::class, 'index'])->name('paciente.index');
     
     #LISTA DE PEDIDOS DE EXAMES DO PACIENTE


### PR DESCRIPTION
Agora não perde mais os dados quando ocorre erros e não é mais possível cadastrar um paciente com nascimento maior que a data atual e com cpf existente